### PR TITLE
Update HTTParty dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: ruby
 rvm:
   - 2.0.0
   - 1.9.3
-  - 1.8.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
+
 # Add dependencies required to use your gem here.
-gem "httparty"
+gem "httparty", "~> 0.13.5"
 gem "mime-types"
 
 # Add dependencies to develop your gem here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,18 +20,18 @@ GEM
     gherkin (2.12.0)
       multi_json (~> 1.3)
     git (1.2.5)
-    httparty (0.11.0)
-      multi_json (~> 1.0)
+    httparty (0.13.5)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
     jeweler (1.8.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
       rdoc
-    json (1.8.0)
+    json (1.8.2)
     mime-types (1.23)
     multi_json (1.7.7)
-    multi_xml (0.5.4)
+    multi_xml (0.5.5)
     rake (10.0.4)
     rdoc (4.0.1)
       json (~> 1.4)
@@ -61,7 +61,7 @@ DEPENDENCIES
   coveralls
   cucumber
   fakeweb
-  httparty
+  httparty (~> 0.13.5)
   jeweler
   mime-types
   rspec

--- a/lib/cloudapp/httparty.rb
+++ b/lib/cloudapp/httparty.rb
@@ -2,7 +2,7 @@ require "json"
 
 module HTTParty #:nodoc:
   
-  class Response < HTTParty::BasicObject #:nodoc:
+  class Response < ::BasicObject #:nodoc:
     def ok?
       [200, 201, 202].include?(self.code)
     end

--- a/lib/cloudapp/response_error.rb
+++ b/lib/cloudapp/response_error.rb
@@ -16,7 +16,7 @@ module CloudApp
       @code     = res.code
       begin
         @errors = parse_errors(res.parsed_response)
-      rescue MultiJson::LoadError => ex
+      rescue JSON::ParserError => ex
         @errors = [res.response.body]
       end
     end


### PR DESCRIPTION
Hello! I tried to use this gem today, but the following steps:

```
$ gem install cloudapp_api
$ irb
>>> irb(main):001:0> require "cloudapp_api"
```

Resulted in the following error:

```irb
NameError: uninitialized constant HTTParty::BasicObject
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cloudapp_api-0.4.0/lib/cloudapp/httparty.rb:5:in `<module:HTTParty>'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cloudapp_api-0.4.0/lib/cloudapp/httparty.rb:3:in `<top (required)>'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cloudapp_api-0.4.0/lib/cloudapp_api.rb:6:in `block in <top (required)>'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cloudapp_api-0.4.0/lib/cloudapp_api.rb:5:in `each'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/cloudapp_api-0.4.0/lib/cloudapp_api.rb:5:in `<top (required)>'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
  from /Users/adammck/.rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
  from (irb):1
  from /Users/adammck/.rbenv/versions/2.1.5/bin/irb:11:in `<main>'
```

It's a pretty simple fix -- this gem seems to have been written back when HTTParty was providing its own implementation of `BasicObject`, which was subsequently removed when (I think) they dropped Ruby 1.8 support. So I just updated the name and fixed the broken tests.